### PR TITLE
Fix typographical error(s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ focus on **big datasets**. It is already possible to cluster dataset without mak
 copy, with different dataset types (bagging, sequential or probability
 sampling). In the near future it will be possible to stream dataset from csv file.
 
-<small>Comparision of performance of original implementation and with
+<small>Comparison of performance of original implementation and with
 improvements suggested by D. Fiser, J. Faigl, M. Kulich </small>
 <center><img src="https://raw.github.com/kudkudak/Growing-Neural-Gas/dev/doc/img/plot_speed.png" width="50%"></img></center>
 


### PR DESCRIPTION
@kudkudak, I've corrected a typographical error in the documentation of the [Growing-Neural-Gas](https://github.com/kudkudak/Growing-Neural-Gas) project. Specifically, I've changed comparision to comparison. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
